### PR TITLE
Integrate MultiMeditron to benchmarking pipeline

### DIFF
--- a/examples/models/llava_next.sh
+++ b/examples/models/llava_next.sh
@@ -16,24 +16,24 @@ python3 -m accelerate.commands.launch \
 # `conv_template` is an arg of the init function of llava in `lmms_eval/models/llava.py`.
 # you could find the corresponding value at LLaVA's code, probably in a dict variable `conv_templates` in `llava/conversations.py`
 
-python3 -m accelerate.commands.launch \
-    --num_processes=8 \
-    -m lmms_eval \
-    --model llava \
-    --model_args pretrained="liuhaotian/llava-v1.6-mistral-7b,conv_template=mistral_instruct" \
-    --tasks mme,mmbench_en \
-    --batch_size 1 \
-    --log_samples \
-    --log_samples_suffix llava_v1.5_mme_mmbenchen \
-    --output_path ./logs/
-
-python3 -m accelerate.commands.launch \
-    --num_processes=8 \
-    -m lmms_eval \
-    --model llava \
-    --model_args pretrained="liuhaotian/llava-v1.6-34b,conv_template=mistral_direct" \
-    --tasks mme,mmbench_en \
-    --batch_size 1 \
-    --log_samples \
-    --log_samples_suffix llava_v1.5_mme_mmbenchen \
-    --output_path ./logs/
+# python3 -m accelerate.commands.launch \
+#     --num_processes=8 \
+#     -m lmms_eval \
+#     --model llava \
+#     --model_args pretrained="liuhaotian/llava-v1.6-mistral-7b,conv_template=mistral_instruct" \
+#     --tasks mme,mmbench_en \
+#     --batch_size 1 \
+#     --log_samples \
+#     --log_samples_suffix llava_v1.5_mme_mmbenchen \
+#     --output_path ./logs/
+#
+# python3 -m accelerate.commands.launch \
+#     --num_processes=8 \
+#     -m lmms_eval \
+#     --model llava \
+#     --model_args pretrained="liuhaotian/llava-v1.6-34b,conv_template=mistral_direct" \
+#     --tasks mme,mmbench_en \
+#     --batch_size 1 \
+#     --log_samples \
+#     --log_samples_suffix llava_v1.5_mme_mmbenchen \
+#     --output_path ./logs/

--- a/examples/models/multimeditron.sh
+++ b/examples/models/multimeditron.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Install package at https://github.com/OpenMeditron/MultiMeditron.git
+# and run this script to evaluate the model on MultiMeditron dataset.
+# pip install git+https://github.com/OpenMeditron/MultiMeditron.git
+
+python3 -m accelerate.commands.launch \
+    --num_processes=8 \
+    -m lmms_eval \
+    --model multimeditron \
+    --model_args pretrained="/mloscratch/users/miczhang/multimodal/MultiMeditron/models/MultiMeditron-8B-Alignment-Image-CLIP/July8/checkpoint-2124/",default_llm="meta-llama/Llama-3.1-8B-Instruct" \
+    --tasks mme \
+    --batch_size 4 \
+    --log_samples \
+    --log_samples_suffix llava_v1.5_mme \
+    --output_path ./logs/
+

--- a/examples/models/multimeditron.sh
+++ b/examples/models/multimeditron.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Install package at https://github.com/OpenMeditron/MultiMeditron.git
 # and run this script to evaluate the model on MultiMeditron dataset.
-# pip install git+https://github.com/OpenMeditron/MultiMeditron.git
+pip install git+https://github.com/OpenMeditron/MultiMeditron.git
 
 python3 -m accelerate.commands.launch \
     --num_processes=8 \
@@ -9,7 +9,7 @@ python3 -m accelerate.commands.launch \
     --model multimeditron \
     --model_args pretrained="/mloscratch/users/miczhang/multimodal/MultiMeditron/models/MultiMeditron-8B-Alignment-Image-CLIP/July8/checkpoint-2124/",default_llm="meta-llama/Llama-3.1-8B-Instruct" \
     --tasks mme \
-    --batch_size 4 \
+    --batch_size 64 \
     --log_samples \
     --log_samples_suffix llava_v1.5_mme \
     --output_path ./logs/

--- a/examples/models/qwen25vl.sh
+++ b/examples/models/qwen25vl.sh
@@ -2,7 +2,7 @@
 # mme as an example
 export HF_HOME="~/.cache/huggingface"
 # pip install git+https://github.com/EvolvingLMMs-Lab/lmms-eval.git
-# pip3 install qwen_vl_utils
+pip3 install qwen_vl_utils
 # use `interleave_visuals=True` to control the visual token position, currently only for mmmu_val and mmmu_pro (and potentially for other interleaved image-text tasks), please do not use it unless you are sure about the operation details.
 
 # accelerate launch --num_processes=8 --main_process_port=12346 -m lmms_eval \
@@ -13,6 +13,6 @@ export HF_HOME="~/.cache/huggingface"
 
 accelerate launch --num_processes=8 --main_process_port=12346 -m lmms_eval \
     --model qwen2_5_vl \
-    --model_args=pretrained=Qwen/Qwen2.5-VL-7B-Instruct,max_pixels=12845056,attn_implementation=flash_attention_2,interleave_visuals=False \
+    --model_args=pretrained=Qwen/Qwen2.5-VL-7B-Instruct,max_pixels=12845056,interleave_visuals=False \
     --tasks mme \
     --batch_size 1

--- a/lmms_eval/models/__init__.py
+++ b/lmms_eval/models/__init__.py
@@ -78,7 +78,8 @@ AVAILABLE_SIMPLE_MODELS = {
     "vora": "VoRA",
 }
 
-AVAILABLE_CHAT_TEMPLATE_MODELS = {"llava_hf": "LlavaHf", "qwen2_5_vl": "Qwen2_5_VL", "openai_compatible": "OpenAICompatible", "vllm": "VLLM", "sglang": "Sglang", "huggingface": "Huggingface", "async_openai": "AsyncOpenAIChat"}
+AVAILABLE_CHAT_TEMPLATE_MODELS = {"llava_hf": "LlavaHf", "qwen2_5_vl": "Qwen2_5_VL", "openai_compatible": "OpenAICompatible", "vllm": "VLLM", "sglang": "Sglang", "huggingface": "Huggingface", "async_openai": "AsyncOpenAIChat", "multimeditron": "MultiMeditron"}
+    
 
 
 def get_model(model_name, force_simple: bool = False):

--- a/lmms_eval/models/chat/multimeditron.py
+++ b/lmms_eval/models/chat/multimeditron.py
@@ -1,0 +1,116 @@
+import logging
+from typing import List, Tuple, Optional, Dict, Any
+from multimeditron.model.model import MultiModalModelForCausalLM
+from multimeditron.model.data_loader import DataCollatorForMultimodal
+import torch
+from transformers import AutoTokenizer
+
+from loguru import logger as eval_logger
+
+from lmms_eval.api.instance import Instance
+from lmms_eval.api.model import lmms
+from lmms_eval.api.registry import register_model
+
+@register_model("multimeditron")
+class MultiMeditron(lmms):
+    is_simple = False
+
+    def __init__(self, pretrained: str, device: str = "cuda", 
+                 attachment_token: str = "<|reserved_special_token_0|>", 
+                 batch_size: int = 4,
+                 tokenizer_type: str = "llama",
+                 **kwargs):
+        super().__init__()
+
+        self.device = device
+        self.model = MultiModalModelForCausalLM.from_pretrained(pretrained, dtype=torch.bfloat16)
+
+        self.model.to(self.device)
+        self.attachment_token = attachment_token
+        
+        try:
+            self.tokenizer = AutoTokenizer.from_pretrained(pretrained)
+        except:
+            default_llm = kwargs.pop("default_llm", None)
+            if default_llm is None:
+                raise ValueError("Default LLM must be specified if tokenizer loading fails.")
+
+            eval_logger.warning(f"Loading tokenizer from {default_llm}")
+            self.tokenizer = AutoTokenizer.from_pretrained(default_llm)
+
+        self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        attachment_token_idx = self.tokenizer.convert_tokens_to_ids(attachment_token) 
+        self.collator = DataCollatorForMultimodal(
+                tokenizer=self.tokenizer,
+                tokenizer_type=tokenizer_type,
+                modality_processors=self.model.processors(), 
+                attachment_token_idx=attachment_token_idx
+        )
+
+        self.batch_size = int(batch_size)
+
+    
+    def generate_until(self, requests: List[Instance]) -> List[str]:
+        results = []
+        all_messages = []
+
+        for request in requests:
+            question, doc_to_messages, gen_kwargs, doc_id, task, split = request.args
+            doc = self.task_dict[task][split][doc_id]
+            messages = self.map_messages_to_multimeditron_format(doc_to_messages(doc))
+            all_messages.append(messages)
+
+        for i in range(0, len(all_messages), self.batch_size):
+            batch_messages = all_messages[i:i + self.batch_size]
+            batch = self.collator(batch_messages)
+
+            outputs = self.model.generate(
+                input_ids=batch["input_ids"],
+                processed_multimodal_inputs=batch["processed_multimodal_inputs"],
+            )
+
+            decoded_outputs = self.tokenizer.batch_decode(outputs, skip_special_tokens=True, clean_up_tokenization_spaces=True)
+
+            eval_logger.info(f"Sample outputs: {decoded_outputs[0]}")
+            results.extend(decoded_outputs)
+
+        return results
+
+
+    def map_messages_to_multimeditron_format(self, messages: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
+        mapped_messages = []
+        modalities = []
+        for message in messages:
+            mapped_text = ""
+            for content_part in message["content"]:
+                match content_part["type"]:
+                    case "text":
+                        mapped_text += content_part["text"]
+                    case "image":
+                        mapped_text += self.attachment_token
+                        modalities.append({
+                            "type" : "image",
+                            "value" : content_part["url"]
+                        })
+                    case _:
+                        eval_logger.warning(f"Skipping unknown content type {content_part['type']}")
+
+            mapped_messages.append({
+                "role" : message["role"],
+                "content" : mapped_text
+            })
+
+        
+        return {
+            "conversations": mapped_messages,
+            "modalities": modalities
+        }
+
+
+    def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
+        return super().loglikelihood(requests)
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        return super().generate_until_multi_round(requests)
+


### PR DESCRIPTION
This pull request adds support for the MultiMeditron model to the codebase, enabling its evaluation and integration alongside other multimodal models. The main changes include implementing a new model class for MultiMeditron, updating the model registry, and providing example scripts for running and evaluating the model. Additionally, there are minor updates to other model scripts and dependencies.

**MultiMeditron model integration:**

* Added a new `MultiMeditron` class in `lmms_eval/models/chat/multimeditron.py` that implements the required API for evaluation, including batching, message formatting, and fallback tokenizer loading.
* Registered `multimeditron` in the `AVAILABLE_CHAT_TEMPLATE_MODELS` dictionary in `lmms_eval/models/__init__.py` to make the model available for evaluation.

**Example scripts and documentation:**

* Added a new script `examples/models/multimeditron.sh` to demonstrate installation and evaluation of the MultiMeditron model.

**Other model script updates:**

* In `examples/models/qwen25vl.sh`, enabled installation of `qwen_vl_utils` by uncommenting the relevant line, and removed the `attn_implementation` argument from the model args for compatibility. [[1]](diffhunk://#diff-5925b579b2c215399d707ed391d4aaef3b0510bbfb41c8aee27ef36cea82b0a1L5-R5) [[2]](diffhunk://#diff-5925b579b2c215399d707ed391d4aaef3b0510bbfb41c8aee27ef36cea82b0a1L16-R16)
* Commented out the LLaVA evaluation launch commands in `examples/models/llava_next.sh` to prevent accidental execution or to serve as reference only.